### PR TITLE
Fixed events display on home page

### DIFF
--- a/js/templates/event-list-format.mustache
+++ b/js/templates/event-list-format.mustache
@@ -1,0 +1,11 @@
+<div class="row news-item padding-bottom-15">
+{{#events}}
+  <div class="col-sm-24">
+    <p class="margin-bottom-0">
+      <a class="fw-700" href="{{ registration }}">{{ title }}</a>
+    </p>
+    <p class="margin-bottom-0">{{ locationName }}</p>
+    <p>{{ date }} - {{ end-date }}</p>
+  </div>
+{{/events}}
+</div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
    <!-- Announcements -->
    <div class="container">
 	  <div id="news" class="row margin-bottom-50">
-	    <div class="col-sm-11 news-list">
+	    <div class="col-sm-15 news-list">
 	      <h2 class="header-underline margin-bottom-30">News</h2>
           <div id="news-list-container" class="news-list" data-news-count="3" data-publish-target="openadx">
           </div>
@@ -11,9 +11,9 @@
             <li class="news-list-links-view-all"><a href="https://newsroom.eclipse.org/node/add/news">Submit News</a></li>
           </ul>
 	    </div>
-	    <div class="col-sm-12 col-sm-offset-1 news-list">
+	    <div class="col-sm-8 col-sm-offset-1 news-list">
 	      <h2 class="header-underline margin-bottom-30">Events</h2>
-          <div id="event-list-container" class="news-items" data-count="3" data-publish-target="openadx">
+          <div id="event-list-container" class="news-items" data-template-id="event-short-list" data-count="3" data-publish-target="openadx">
           </div>
           <ul class="list-inline block-summary-more margin-bottom-40">
             <li><a href="https://events.eclipse.org">View all</a></li>

--- a/layouts/partials/footer_suffix.html
+++ b/layouts/partials/footer_suffix.html
@@ -1,3 +1,6 @@
+<script id="event-short-list" type="text/html">
+{{ readFile ("/js/templates/event-list-format.mustache") | safeHTML}}
+</script>
 <script>
 (function($, document) {
   // Eclipse News and events


### PR DESCRIPTION
Updated column size to match other sites (16:8 for news:events) and made
use of event list template to display events on the site.

Signed-off-by: Martin Lowe <martin.lowe@eclipse-foundation.org>